### PR TITLE
Updates to Files Controller for Rails compatibility

### DIFF
--- a/app/controllers/rich/files_controller.rb
+++ b/app/controllers/rich/files_controller.rb
@@ -1,8 +1,8 @@
 module Rich
   class FilesController < ApplicationController
 
-    before_filter :authenticate_rich_user
-    before_filter :set_rich_file, only: [:show, :destroy]
+    before_action :authenticate_rich_user
+    before_action :set_rich_file, only: [:show, :destroy]
 
     layout "rich/application"
 


### PR DESCRIPTION
Rails 5 was unable to load this because before_filter was still used instead of before_action.